### PR TITLE
Fix NRE in BackpackNetworkController.Subscribe

### DIFF
--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -4820,7 +4820,7 @@ namespace Oxide.Plugins
 
             public void Subscribe(BasePlayer player)
             {
-                if (player.Connection == null || _subscribers.Contains(player))
+                if (player.Connection == null || player.net == null || _subscribers.Contains(player))
                     return;
 
                 _subscribers.Add(player);


### PR DESCRIPTION
## Fix NullReferenceException in BackpackNetworkController.Subscribe

### Problem
After today's Rust update, a NullReferenceException occurs in `BackpackNetworkController.Subscribe`:

```
NullReferenceException: Object reference not set to an instance of an object
at Oxide.Plugins.Backpacks+BackpackNetworkController.Subscribe (BasePlayer player)
```

### Root Cause
The Rust update appears to have changed timing behavior such that `player.net` can be `null` by the time the timer callback executes, even when `player.Connection` is not null. The player may have disconnected or respawned during the 0.1s delay before `Subscribe` is called.

### Fix
Added `player.net == null` to the existing null check at the start of the `Subscribe` method:

```csharp
if (player.Connection == null || player.net == null || _subscribers.Contains(player))
    return;
```

### Testing
This fix adds defensive null checking without changing any other behavior. Players who disconnect before the backpack opens will simply be skipped, which is the correct behavior.